### PR TITLE
Crop offset with or without bbox argument

### DIFF
--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -37,8 +37,6 @@ def grab(bbox=None, include_layered_windows=False, multimonitor=False):
         im = Image.open(filepath)
         im.load()
         os.unlink(filepath)
-        if bbox:
-            im = im.crop(bbox)
     else:
         offset, size, data = grabber(include_layered_windows, multimonitor)
         im = Image.frombytes(
@@ -51,10 +49,13 @@ def grab(bbox=None, include_layered_windows=False, multimonitor=False):
             (size[0] * 3 + 3) & -4,
             -1,
         )
-        if bbox:
-            x0, y0 = offset
-            left, top, right, bottom = bbox
-            im = im.crop((left - x0, top - y0, right - x0, bottom - y0))
+        x0, y0 = offset
+        if x0 != 0 or y0 != 0:
+            if not bbox:
+                bbox = (0, 0, im.width, im.height)
+            bbox = (bbox[0] - x0, bbox[1] - y0, bbox[2] - x0, bbox[3] - y0)
+    if bbox:
+        im = im.crop(bbox)
     return im
 
 


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/pull/3950

Correct me if I'm wrong - if you're going to crop the offset from the image, then it would seem that you should crop it whether or not there is a `bbox` argument given by the user.