### PR TITLE
ImageGrab with XCB tests

### DIFF
--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -32,15 +32,9 @@ class TestImageGrab(PillowTestCase):
 
     @unittest.skipUnless(Image.core.HAVE_XCB, "requires XCB")
     def test_grab_invalid_xdisplay(self):
-        exception = None
-
-        try:
+        with self.assertRaises(IOError) as e:
             ImageGrab.grab(xdisplay="error.test:0.0")
-        except Exception as e:
-            exception = e
-
-        self.assertIsInstance(exception, IOError)
-        self.assertTrue(str(exception).startswith("X connection failed"))
+        self.assertTrue(str(e.exception).startswith("X connection failed"))
 
     def test_grabclipboard(self):
         if sys.platform == "darwin":
@@ -55,16 +49,10 @@ $bmp = New-Object Drawing.Bitmap 200, 200
             )
             p.communicate()
         else:
-            exception = None
-
-            try:
+            with self.assertRaises(NotImplementedError) as e:
                 ImageGrab.grabclipboard()
-            except IOError as e:
-                exception = e
-
-            self.assertIsInstance(exception, IOError)
             self.assertEqual(
-                str(exception), "ImageGrab.grabclipboard() is macOS and Windows only"
+                str(e.exception), "ImageGrab.grabclipboard() is macOS and Windows only"
             )
             return
 

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -35,11 +35,15 @@ class TestImageGrab(PillowTestCase):
         if sys.platform not in ("win32", "darwin"):
             with self.assertRaises(IOError) as e:
                 ImageGrab.grab()
-            self.assertTrue(str(e.exception).startswith("Pillow was built without XCB support"))
+            self.assertTrue(
+                str(e.exception).startswith("Pillow was built without XCB support")
+            )
 
         with self.assertRaises(IOError) as e:
             ImageGrab.grab(xdisplay="")
-        self.assertTrue(str(e.exception).startswith("Pillow was built without XCB support"))
+        self.assertTrue(
+            str(e.exception).startswith("Pillow was built without XCB support")
+        )
 
     @unittest.skipUnless(Image.core.HAVE_XCB, "requires XCB")
     def test_grab_invalid_xdisplay(self):

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -30,6 +30,17 @@ class TestImageGrab(PillowTestCase):
         except IOError as e:
             self.skipTest(str(e))
 
+    @unittest.skipIf(Image.core.HAVE_XCB, "tests missing XCB")
+    def test_grab_no_xcb(self):
+        if sys.platform not in ("win32", "darwin"):
+            with self.assertRaises(IOError) as e:
+                ImageGrab.grab()
+            self.assertTrue(str(e.exception).startswith("Pillow was built without XCB support"))
+
+        with self.assertRaises(IOError) as e:
+            ImageGrab.grab(xdisplay="")
+        self.assertTrue(str(e.exception).startswith("Pillow was built without XCB support"))
+
     @unittest.skipUnless(Image.core.HAVE_XCB, "requires XCB")
     def test_grab_invalid_xdisplay(self):
         with self.assertRaises(IOError) as e:

--- a/src/display.c
+++ b/src/display.c
@@ -898,7 +898,7 @@ PyImaging_GrabScreenX11(PyObject* self, PyObject* args)
         buffer = PyBytes_FromStringAndSize((char*)xcb_get_image_data(reply),
                                            xcb_get_image_data_length(reply));
     } else {
-        PyErr_Format(PyExc_IOError, "usupported bit depth: %i", reply->depth);
+        PyErr_Format(PyExc_IOError, "unsupported bit depth: %i", reply->depth);
     }
 
     free(reply);


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/pull/4260

- Updates the tests for the new error type that I suggested
- Adds a test if XCB is not available
- Fixed typo