### PR TITLE
Fix isort

### DIFF
--- a/Tests/test_file_palm.py
+++ b/Tests/test_file_palm.py
@@ -2,7 +2,6 @@ import os.path
 import subprocess
 
 import pytest
-
 from PIL import Image
 
 from .helper import IMCONVERT, assert_image_equal, hopper, imagemagick_available


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/pull/4698.

When I run `isort` I get this:

```diff
diff --git a/Tests/test_file_palm.py b/Tests/test_file_palm.py
index 25d194b6..e7afeef2 100644
--- a/Tests/test_file_palm.py
+++ b/Tests/test_file_palm.py
@@ -2,7 +2,6 @@ import os.path
 import subprocess

 import pytest
-
 from PIL import Image

 from .helper import IMCONVERT, assert_image_equal, hopper, imagemagick_available
```

I get the same result when running my system isort (`isort -y`), and the one in pre-commit (`pre-commit run --all` or `pre-commit run --all isort`). Both are version 4.3.21. What do you have?