### PR TITLE
Altered descriptions

### DIFF
--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -333,15 +333,14 @@ Instances of the :py:class:`Image` class have the following attributes:
 .. py:attribute:: Image.is_animated
     :type: bool
 
-    This attribute is ``True`` if the Image is animated, ``False`` otherwise.
-    Typically defined as ``Image.n_frames > 1``.
+    ``True`` if this image has more than one frame, or ``False`` otherwise.
 
-    This attribute is only defined by Image plugins that support animated Images.
+    This attribute is only defined by image plugins that support animated images.
     Plugins may leave this attribute undefined if they don't support loading
-    animated images, even if the given format supports animated images. Use
-    ``hasattr(image, "is_animated")`` to check whether the implementation
-    supports animated images, or ``getattr(image, "is_animated", False)``
-    to check whether an image has been loaded with animation support.
+    animated images, even if the given format supports animated images.
+
+    To check whether an image is animated regardless of its format, use
+    ``getattr(image, "is_animated", False)``.
 
     .. seealso:: :attr:`~Image.n_frames`, :func:`~Image.seek` and :func:`~Image.tell`
 
@@ -349,15 +348,13 @@ Instances of the :py:class:`Image` class have the following attributes:
     :type: int
 
     The number of frames in this image.
-    Defined if and only if :attr:`~Image.is_animated` is also defined.
-    Equal to 1 for non-animated images loaded by a plugin supporting animations.
 
-    This attribute is only defined by Image plugins that support animated Images.
+    This attribute is only defined by image plugins that support animated images.
     Plugins may leave this attribute undefined if they don't support loading
-    animated images, even if the given format supports animated images. Use
-    ``hasattr(image, "is_animated")`` to check whether the implementation
-    supports animated images, or ``getattr(image, "n_frames", 1)``
-    to check whether an image has been loaded with more than one frame.
+    animated images, even if the given format supports animated images.
+
+    To check the number of frames in an image regardless of its format, use
+    ``getattr(image, "n_frames", 1)``.
 
     .. seealso:: :attr:`~Image.is_animated`, :func:`~Image.seek` and :func:`~Image.tell`
 


### PR DESCRIPTION
My suggestions for https://github.com/python-pillow/Pillow/pull/4739. Feel free to leave the PR as is if you disagree.

My thinking behind these changes
- I've replaced a few references to 'Image' with 'image'. I think we support all animated instances of the Image class, but not all animated image files. I think they are not 'Image plugins', plugins for the Image class, but 'image plugins', plugins for images.
- I've removed 'Defined if and only if Image.is_animated is also defined.' I think this makes it sound like they are always bound together in the code, which they are not. It is also possible that a custom plugin could have one but not the other.
- I've removed 'Use hasattr(image, "is_animated") to check whether the implementation supports animated images'. When Pillow opens an image, it might be a GifImageFile, for instance. But an `im.copy()` operation changes it to be a generic `Image` without multiple frames, and I'm concerned that instructing users to check our level of support for animation in this way might lead to some incorrect conclusions.