### PR TITLE
Catch OSError

### DIFF
--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -269,4 +269,7 @@ def test_crashes(test_file):
     with open(test_file, "rb") as f:
         with Image.open(f) as im:
             # Valgrind should not complain here
-            im.load()
+            try:
+                im.load()
+            except OSError:
+                pass


### PR DESCRIPTION
I merged master into https://github.com/python-pillow/Pillow/pull/4996/, but now the tests are failing - at least one of the crash images is throwing an error. This PR catches it.