### PR TITLE
Deprecate FreeTypeFont.getmask2 fill parameter

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -149,6 +149,14 @@ PhotoImage.paste box parameter
 
 The ``box`` parameter is unused. It will be removed in Pillow 10.0.0 (2023-07-01).
 
+FreeTypeFont.getmask2 fill parameter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 9.2.0
+
+The undocumented ``fill`` parameter of :py:meth:`.FreeTypeFont.getmask2` has been
+deprecated and will be removed in Pillow 10 (2023-07-01).
+
 Removed features
 ----------------
 

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -630,7 +630,10 @@ class FreeTypeFont:
 
                      .. versionadded:: 1.1.5
 
-        :param fill: Fill function. Deprecated.
+        :param fill: Optional fill function. By default, an internal Pillow function
+                     will be used.
+
+                     Deprecated.
 
         :param direction: Direction of the text. It can be 'rtl' (right to
                           left), 'ltr' (left to right) or 'ttb' (top to bottom).

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -633,7 +633,8 @@ class FreeTypeFont:
         :param fill: Optional fill function. By default, an internal Pillow function
                      will be used.
 
-                     Deprecated.
+                     Deprecated. This parameter will be removed in Pillow 10
+                     (2023-07-01).
 
         :param direction: Direction of the text. It can be 'rtl' (right to
                           left), 'ltr' (left to right) or 'ttb' (top to bottom).


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/6220