### PR TITLE
Replaced __internal__ argument with module attribute

### DIFF
--- a/src/PIL/ImageDraw2.py
+++ b/src/PIL/ImageDraw2.py
@@ -24,8 +24,7 @@
 """
 
 
-from . import Image, ImageColor, ImageDraw, ImageFont, ImagePath
-from ._deprecate import deprecate
+from . import Image, ImageColor, ImageDraw, ImageFont, ImagePath, _deprecate
 
 
 class Pen:
@@ -177,8 +176,13 @@ class Draw:
 
         .. seealso:: :py:meth:`PIL.ImageDraw.ImageDraw.textsize`
         """
-        deprecate("textsize", 10, "textbbox or textlength")
-        return self.draw.textsize(text, font=font.font, __internal__=True)
+        _deprecate.deprecate("textsize", 10, "textbbox or textlength")
+        _deprecate._suppress_internal_deprecations = True
+        try:
+            size = self.draw.textsize(text, font=font.font)
+        finally:
+            _deprecate._suppress_internal_deprecations = False
+        return size
 
     def textbbox(self, xy, text, font):
         """

--- a/src/PIL/_deprecate.py
+++ b/src/PIL/_deprecate.py
@@ -4,6 +4,8 @@ import warnings
 
 from . import __version__
 
+_suppress_internal_deprecations = False
+
 
 def deprecate(
     deprecated: str,


### PR DESCRIPTION
Suggestion for [#6381](https://github.com/python-pillow/Pillow/pull/6381)

Rather than adding an `__internal__` argument to method definitions, this PR adds and removes a `_deprecate._suppress_internal_deprecations` setting.

This may or may not be preferable. See what you think.