### PR TITLE
Added documentation and release notes

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -178,6 +178,22 @@ Image.coerce_e
 This undocumented method has been deprecated and will be removed in Pillow 10
 (2023-07-01).
 
+Font size and offset methods
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. deprecated:: 9.2.0
+
+=========================================================================== =============================================================================================================
+Deprecated                                                                  Use instead
+=========================================================================== =============================================================================================================
+:py:meth:`.FreeTypeFont.getsize` and :py:meth:`.FreeTypeFont.getoffset`     :py:meth:`.FreeTypeFont.getbbox` and :py:meth:`.FreeTypeFont.getlength`
+:py:meth:`.FreeTypeFont.getsize_multiline`                                  :py:meth:`.ImageDraw.multiline_textbbox`
+:py:meth:`.ImageFont.getsize`                                               :py:meth:`.ImageFont.getbbox` and :py:meth:`.ImageFont.getlength`
+:py:meth:`.TransposedFont.getsize`                                          :py:meth:`.TransposedFont.getbbox` and :py:meth:`.TransposedFont.getlength`
+:py:meth:`.ImageDraw.textsize` and :py:meth:`.ImageDraw.multiline_textsize` :py:meth:`.ImageDraw.textbbox`, :py:meth:`.ImageDraw.textlength` and :py:meth:`.ImageDraw.multiline_textbbox`
+``ImageDraw2.Draw().textsize``                                              ``ImageDraw2.Draw().textbbox`` and ``ImageDraw2.Draw().textlength``
+=========================================================================== =============================================================================================================
+
 Removed features
 ----------------
 

--- a/docs/reference/ImageFont.rst
+++ b/docs/reference/ImageFont.rst
@@ -56,6 +56,7 @@ Methods
 
 .. autoclass:: PIL.ImageFont.TransposedFont
     :members:
+    :undoc-members:
 
 Constants
 ---------

--- a/docs/releasenotes/9.2.0.rst
+++ b/docs/releasenotes/9.2.0.rst
@@ -40,6 +40,22 @@ Image.coerce_e
 This undocumented method has been deprecated and will be removed in Pillow 10
 (2023-07-01).
 
+Font size and offset methods
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. deprecated:: 9.2.0
+
+=========================================================================== =============================================================================================================
+Deprecated                                                                  Use instead
+=========================================================================== =============================================================================================================
+:py:meth:`.FreeTypeFont.getsize` and :py:meth:`.FreeTypeFont.getoffset`     :py:meth:`.FreeTypeFont.getbbox` and :py:meth:`.FreeTypeFont.getlength`
+:py:meth:`.FreeTypeFont.getsize_multiline`                                  :py:meth:`.ImageDraw.multiline_textbbox`
+:py:meth:`.ImageFont.getsize`                                               :py:meth:`.ImageFont.getbbox` and :py:meth:`.ImageFont.getlength`
+:py:meth:`.TransposedFont.getsize`                                          :py:meth:`.TransposedFont.getbbox` and :py:meth:`.TransposedFont.getlength`
+:py:meth:`.ImageDraw.textsize` and :py:meth:`.ImageDraw.multiline_textsize` :py:meth:`.ImageDraw.textbbox`, :py:meth:`.ImageDraw.textlength` and :py:meth:`.ImageDraw.multiline_textbbox`
+``ImageDraw2.Draw().textsize``                                              ``ImageDraw2.Draw().textbbox`` and ``ImageDraw2.Draw().textlength``
+=========================================================================== =============================================================================================================
+
 API Additions
 =============
 


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/pull/6381

See https://pillow-radarhere.readthedocs.io/en/deprecate-getsize-docs/releasenotes/9.2.0.html#font-size-and-offset-methods and https://pillow-radarhere.readthedocs.io/en/deprecate-getsize-docs/deprecations.html#font-size-and-offset-methods for how this is rendered.