### PR TITLE
Documented deprecation in individual methods

### DIFF
--- a/docs/reference/ImageDraw.rst
+++ b/docs/reference/ImageDraw.rst
@@ -436,6 +436,8 @@ Methods
 
 .. py:method:: ImageDraw.textsize(text, font=None, spacing=4, direction=None, features=None, language=None, stroke_width=0)
 
+    .. deprecated:: 9.2.0
+
     Return the size of the given string, in pixels.
 
     Use :py:meth:`textlength()` to measure the offset of following text with
@@ -483,6 +485,8 @@ Methods
                      .. versionadded:: 6.2.0
 
 .. py:method:: ImageDraw.multiline_textsize(text, font=None, spacing=4, direction=None, features=None, language=None, stroke_width=0)
+
+    .. deprecated:: 9.2.0
 
     Return the size of the given string, in pixels.
 

--- a/src/PIL/ImageDraw2.py
+++ b/src/PIL/ImageDraw2.py
@@ -173,6 +173,8 @@ class Draw:
 
     def textsize(self, text, font):
         """
+        .. deprecated:: 9.2.0
+
         Return the size of the given string, in pixels.
 
         .. seealso:: :py:meth:`PIL.ImageDraw.ImageDraw.textsize`

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -137,6 +137,8 @@ class ImageFont:
 
     def getsize(self, text, *args, **kwargs):
         """
+        .. deprecated:: 9.2.0
+
         Returns width and height (in pixels) of given text.
 
         :param text: Text to measure.
@@ -424,6 +426,8 @@ class FreeTypeFont:
         __internal__=False,
     ):
         """
+        .. deprecated:: 9.2.0
+
         Returns width and height (in pixels) of given text if rendered in font with
         provided direction, features, and language.
 
@@ -493,6 +497,8 @@ class FreeTypeFont:
         stroke_width=0,
     ):
         """
+        .. deprecated:: 9.2.0
+
         Returns width and height (in pixels) of given text if rendered in font
         with provided direction, features, and language, while respecting
         newline characters.
@@ -548,6 +554,8 @@ class FreeTypeFont:
 
     def getoffset(self, text):
         """
+        .. deprecated:: 9.2.0
+
         Returns the offset of given text. This is the gap between the
         starting coordinate and the first marking. Note that this gap is
         included in the result of :py:func:`~PIL.ImageFont.FreeTypeFont.getsize`.
@@ -837,6 +845,9 @@ class TransposedFont:
         self.orientation = orientation  # any 'transpose' argument, or None
 
     def getsize(self, text, *args, **kwargs):
+        """
+        .. deprecated:: 9.2.0
+        """
         if not kwargs.get("__internal__"):
             deprecate("getsize", 10, "getbbox or getlength")
         try:


### PR DESCRIPTION
Follow up to #16 for https://github.com/python-pillow/Pillow/pull/6381

Adds the deprecation notice to individual methods in the documentation
- https://pillow-radarhere.readthedocs.io/en/deprecate-getsize-docs/reference/ImageFont.html#PIL.ImageFont.FreeTypeFont.getsize
- https://pillow-radarhere.readthedocs.io/en/deprecate-getsize-docs/reference/ImageFont.html#PIL.ImageFont.FreeTypeFont.getoffset
- https://pillow-radarhere.readthedocs.io/en/deprecate-getsize-docs/reference/ImageFont.html#PIL.ImageFont.FreeTypeFont.getsize_multiline
- https://pillow-radarhere.readthedocs.io/en/deprecate-getsize-docs/reference/ImageFont.html#PIL.ImageFont.ImageFont.getsize
- https://pillow-radarhere.readthedocs.io/en/deprecate-getsize-docs/reference/ImageFont.html#PIL.ImageFont.TransposedFont.getsize
- https://pillow-radarhere.readthedocs.io/en/deprecate-getsize-docs/reference/ImageDraw.html#PIL.ImageDraw.ImageDraw.textsize
- https://pillow-radarhere.readthedocs.io/en/deprecate-getsize-docs/reference/ImageDraw.html#PIL.ImageDraw.ImageDraw.multiline_textsize
- https://pillow-radarhere.readthedocs.io/en/deprecate-getsize-docs/PIL.html?highlight=draw2#PIL.ImageDraw2.Draw.textsize