### PR TITLE
Revert "add xfail mark to `test_qt_image_qapplication.py::test_sanity`"

### DIFF
--- a/Tests/test_qt_image_qapplication.py
+++ b/Tests/test_qt_image_qapplication.py
@@ -51,7 +51,6 @@ def roundtrip(expected):
     assert_image_similar(result, expected.convert("RGB"), 0.3)
 
 
-@pytest.mark.xfail(reason="Flaky test")
 @pytest.mark.skipif(not ImageQt.qt_is_installed, reason="Qt bindings are not installed")
 def test_sanity(tmp_path):
     # Segfault test


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/6888

Given that https://github.com/python-pillow/Pillow/pull/6915 has been merged into main, I'm hoping that test_qt_image_qapplication.py::test_sanity will pass more consistently now.