### PR TITLE
Remove implication that "-C" is since Pillow 3.0.0

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -151,13 +151,13 @@ Many of Pillow's features require external libraries:
 
   * Pillow has been tested with libjpeg versions **6b**, **8**, **9-9d** and
     libjpeg-turbo version **8**.
-  * Starting with Pillow 3.0.0, libjpeg is required by default, but
-    may be disabled with the ``-C jpeg=disable`` flag.
+  * Starting with Pillow 3.0.0, libjpeg is required by default. It can be
+    disabled with the ``-C jpeg=disable`` flag.
 
 * **zlib** provides access to compressed PNGs
 
-  * Starting with Pillow 3.0.0, zlib is required by default, but may
-    be disabled with the ``-C zlib=disable`` flag.
+  * Starting with Pillow 3.0.0, zlib is required by default. It can be
+    disabled with the ``-C zlib=disable`` flag.
 
 * **libtiff** provides compressed TIFF functionality
 


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/7564

I feel a bit weird about
> Starting with Pillow 3.0.0, libjpeg is required by default, but may be disabled with the ``-C jpeg=disable`` flag.

since "libjpeg is required by default" is since Pillow 3.0.0, but ``-C jpeg=disable`` isn't until much later. My suggestion is to split this into two sentences?