### PR TITLE
Gcc warning demo

### DIFF
--- a/.github/problem-matchers/gcc.json
+++ b/.github/problem-matchers/gcc.json
@@ -1,0 +1,18 @@
+{
+    "__comment": "Based on vscode-cpptools' Extension/package.json gcc rule",
+    "problemMatcher": [
+        {
+            "owner": "gcc-problem-matcher",
+            "pattern": [
+                {
+                    "regexp": "^\\s*(.*):(\\d+):(\\d+):\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,10 @@ jobs:
       env:
         GHA_PYTHON_VERSION: ${{ matrix.python-version }}
 
+    - name: Register gcc problem matcher
+      if: "matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'"
+      run: echo "::add-matcher::.github/problem-matchers/gcc.json"
+
     - name: Build
       run: |
         .ci/build.sh

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -720,6 +720,7 @@ _radial_gradient(PyObject *self, PyObject *args) {
 
 static PyObject *
 _alpha_composite(ImagingObject *self, PyObject *args) {
+    int x;
     ImagingObject *imagep1;
     ImagingObject *imagep2;
 


### PR DESCRIPTION
Demo for https://github.com/python-pillow/Pillow/pull/7585.

There are two annotations here because the workflow was triggered twice, for the push and for the pull-request separately.
This shouldn't happen on the upstream repo.