### PR TITLE
Simplify references to TrueType fonts

### DIFF
--- a/docs/reference/ImageDraw.rst
+++ b/docs/reference/ImageDraw.rst
@@ -363,8 +363,8 @@ Methods
     :param font: An :py:class:`~PIL.ImageFont.ImageFont` instance.
     :param anchor: The text anchor alignment. Determines the relative location of
                    the anchor to the text. The default alignment is top left,
-                   specifically ``la`` for horizontal text with a TrueType font
-                   and ``lt`` otherwise. See :ref:`text-anchors` for details.
+                   specifically ``la`` for horizontal text and ``lt`` for
+                   vertical text. See :ref:`text-anchors` for details.
                    This parameter is ignored for non-TrueType fonts.
 
                     .. note:: This parameter was present in earlier versions
@@ -435,8 +435,8 @@ Methods
 
     :param anchor: The text anchor alignment. Determines the relative location of
                    the anchor to the text. The default alignment is top left,
-                   specifically ``la`` for horizontal text with a TrueType font
-                   and ``lt`` otherwise. See :ref:`text-anchors` for details.
+                   specifically ``la`` for horizontal text and ``lt`` for
+                   vertical text. See :ref:`text-anchors` for details.
                    This parameter is ignored for non-TrueType fonts.
 
                     .. note:: This parameter was present in earlier versions
@@ -579,8 +579,8 @@ Methods
     :param font: A :py:class:`~PIL.ImageFont.FreeTypeFont` instance.
     :param anchor: The text anchor alignment. Determines the relative location of
                    the anchor to the text. The default alignment is top left,
-                   specifically ``la`` for horizontal text with a TrueType font
-                   and ``lt`` otherwise. See :ref:`text-anchors` for details.
+                   specifically ``la`` for horizontal text and ``lt`` for
+                   vertical text. See :ref:`text-anchors` for details.
                    This parameter is ignored for non-TrueType fonts.
     :param spacing: If the text is passed on to
                     :py:meth:`~PIL.ImageDraw.ImageDraw.multiline_textbbox`,
@@ -634,8 +634,8 @@ Methods
     :param font: A :py:class:`~PIL.ImageFont.FreeTypeFont` instance.
     :param anchor: The text anchor alignment. Determines the relative location of
                    the anchor to the text. The default alignment is top left,
-                   specifically ``la`` for horizontal text with a TrueType font
-                   and ``lt`` otherwise. See :ref:`text-anchors` for details.
+                   specifically ``la`` for horizontal text and ``lt`` for
+                   vertical text. See :ref:`text-anchors` for details.
                    This parameter is ignored for non-TrueType fonts.
     :param spacing: The number of pixels between lines.
     :param align: ``"left"``, ``"center"`` or ``"right"``. Determines the relative alignment of lines.

--- a/docs/reference/ImageDraw.rst
+++ b/docs/reference/ImageDraw.rst
@@ -362,9 +362,10 @@ Methods
     :param fill: Color to use for the text.
     :param font: An :py:class:`~PIL.ImageFont.ImageFont` instance.
     :param anchor: The text anchor alignment. Determines the relative location of
-                   the anchor to the text. The default alignment is top left.
-                   See :ref:`text-anchors` for valid values. This parameter is
-                   ignored for non-TrueType fonts.
+                   the anchor to the text. The default alignment is top left,
+                   specifically ``la`` for horizontal text with a TrueType font
+                   and ``lt`` otherwise. See :ref:`text-anchors` for details.
+                   This parameter is ignored for non-TrueType fonts.
 
                     .. note:: This parameter was present in earlier versions
                               of Pillow, but implemented only in version 8.0.0.
@@ -433,9 +434,10 @@ Methods
     :param font: An :py:class:`~PIL.ImageFont.ImageFont` instance.
 
     :param anchor: The text anchor alignment. Determines the relative location of
-                   the anchor to the text. The default alignment is top left.
-                   See :ref:`text-anchors` for valid values. This parameter is
-                   ignored for non-TrueType fonts.
+                   the anchor to the text. The default alignment is top left,
+                   specifically ``la`` for horizontal text with a TrueType font
+                   and ``lt`` otherwise. See :ref:`text-anchors` for details.
+                   This parameter is ignored for non-TrueType fonts.
 
                     .. note:: This parameter was present in earlier versions
                               of Pillow, but implemented only in version 8.0.0.
@@ -576,9 +578,10 @@ Methods
                  :py:meth:`~PIL.ImageDraw.ImageDraw.multiline_textbbox`.
     :param font: A :py:class:`~PIL.ImageFont.FreeTypeFont` instance.
     :param anchor: The text anchor alignment. Determines the relative location of
-                   the anchor to the text. The default alignment is top left.
-                   See :ref:`text-anchors` for valid values. This parameter is
-                   ignored for non-TrueType fonts.
+                   the anchor to the text. The default alignment is top left,
+                   specifically ``la`` for horizontal text with a TrueType font
+                   and ``lt`` otherwise. See :ref:`text-anchors` for details.
+                   This parameter is ignored for non-TrueType fonts.
     :param spacing: If the text is passed on to
                     :py:meth:`~PIL.ImageDraw.ImageDraw.multiline_textbbox`,
                     the number of pixels between lines.
@@ -630,9 +633,10 @@ Methods
     :param text: Text to be measured.
     :param font: A :py:class:`~PIL.ImageFont.FreeTypeFont` instance.
     :param anchor: The text anchor alignment. Determines the relative location of
-                   the anchor to the text. The default alignment is top left.
-                   See :ref:`text-anchors` for valid values. This parameter is
-                   ignored for non-TrueType fonts.
+                   the anchor to the text. The default alignment is top left,
+                   specifically ``la`` for horizontal text with a TrueType font
+                   and ``lt`` otherwise. See :ref:`text-anchors` for details.
+                   This parameter is ignored for non-TrueType fonts.
     :param spacing: The number of pixels between lines.
     :param align: ``"left"``, ``"center"`` or ``"right"``. Determines the relative alignment of lines.
                   Use the ``anchor`` parameter to specify the alignment to ``xy``.

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -375,8 +375,9 @@ class FreeTypeFont:
         :param stroke_width: The width of the text stroke.
 
         :param anchor:  The text anchor alignment. Determines the relative location of
-                        the anchor to the text. The default alignment is top left.
-                        See :ref:`text-anchors` for valid values.
+                        the anchor to the text. The default alignment is top left,
+                        specifically ``la`` for horizontal text and ``lt`` for vertical
+                        text. See :ref:`text-anchors` for details.
 
         :return: ``(left, top, right, bottom)`` bounding box
         """
@@ -449,8 +450,9 @@ class FreeTypeFont:
                          .. versionadded:: 6.2.0
 
         :param anchor:  The text anchor alignment. Determines the relative location of
-                        the anchor to the text. The default alignment is top left.
-                        See :ref:`text-anchors` for valid values.
+                        the anchor to the text. The default alignment is top left,
+                        specifically ``la`` for horizontal text and ``lt`` for vertical
+                        text. See :ref:`text-anchors` for details.
 
                          .. versionadded:: 8.0.0
 
@@ -541,8 +543,9 @@ class FreeTypeFont:
                          .. versionadded:: 6.2.0
 
         :param anchor:  The text anchor alignment. Determines the relative location of
-                        the anchor to the text. The default alignment is top left.
-                        See :ref:`text-anchors` for valid values.
+                        the anchor to the text. The default alignment is top left,
+                        specifically ``la`` for horizontal text and ``lt`` for vertical
+                        text. See :ref:`text-anchors` for details.
 
                          .. versionadded:: 8.0.0
 


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/7600

In ImageDraw,
> The default alignment is top left, specifically ``la`` for horizontal text with a TrueType font and ``lt`` otherwise. See :ref:`text-anchors` for details. This parameter is ignored for non-TrueType fonts.

I look at this and think
> _Ok, so it is ``la`` if it's horizontal text AND TrueType, and ``lt`` the rest of the time... oh, no, that's not it, "This parameter is ignored for non-TrueType fonts"_

So I'm suggesting this instead.
> The default alignment is top left, specifically ``la`` for horizontal text and ``lt`` for vertical text. See :ref:`text-anchors` for details. This parameter is ignored for non-TrueType fonts.