### PR TITLE
Moved code into sequential order

### DIFF
--- a/src/PIL/PpmImagePlugin.py
+++ b/src/PIL/PpmImagePlugin.py
@@ -147,9 +147,12 @@ class PpmImageFile(ImageFile.ImageFile):
                         elif maxval != 255:
                             decoder_name = "ppm"
 
-        row_order = -1 if mode == "F" else 1
-        args = (rawmode, 0, row_order) if decoder_name == "raw" else (rawmode, maxval)
         self._size = xsize, ysize
+        if decoder_name == "raw":
+            row_order = -1 if mode == "F" else 1
+            args = (rawmode, 0, row_order)
+        else:
+            args = (rawmode, maxval)
         self.tile = [(decoder_name, (0, 0, xsize, ysize), self.fp.tell(), args)]
 
 
@@ -319,7 +322,6 @@ class PpmDecoder(ImageFile.PyDecoder):
 
 
 def _save(im, fp, filename):
-    row_order = 1
     if im.mode == "1":
         rawmode, head = "1;I", b"P4"
     elif im.mode == "L":
@@ -330,7 +332,6 @@ def _save(im, fp, filename):
         rawmode, head = "RGB", b"P6"
     elif im.mode == "F":
         rawmode, head = "F;32F", b"Pf"
-        row_order = -1
     else:
         msg = f"cannot write mode {im.mode} as PPM"
         raise OSError(msg)
@@ -344,6 +345,7 @@ def _save(im, fp, filename):
             fp.write(b"65535\n")
     elif head == b"Pf":
         fp.write(b"-1.0\n")
+    row_order = -1 if im.mode == "F" else 1
     ImageFile._save(im, fp, [("raw", (0, 0) + im.size, 0, (rawmode, 0, row_order))])
 
 


### PR DESCRIPTION
Two suggestions for https://github.com/python-pillow/Pillow/pull/7696.
- Moved code into sequential order, so that the `if mode == "F" and ix == 2:` block occurs with the rest of the `ix == 2` code.
- Only set `row_order` when needed