### PR TITLE
Link to Python enum documentation

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -64,33 +64,33 @@ A number of constants and a function in :py:mod:`.ImageCms` have been deprecated
 This includes a table of flags based on LittleCMS version 1 which has been
 replaced with a new class :py:class:`.ImageCms.Flags` based on LittleCMS 2 flags.
 
-=====================================================  ============================================================
-Deprecated                                             Use instead
-=====================================================  ============================================================
-``ImageCms.DESCRIPTION``                               No replacement
-``ImageCms.VERSION``                                   ``PIL.__version__``
-``ImageCms.FLAGS["MATRIXINPUT"]``                      :py:attr:`.ImageCms.Flags.CLUT_POST_LINEARIZATION`
-``ImageCms.FLAGS["MATRIXOUTPUT"]``                     :py:attr:`.ImageCms.Flags.FORCE_CLUT`
-``ImageCms.FLAGS["MATRIXONLY"]``                       No replacement
-``ImageCms.FLAGS["NOWHITEONWHITEFIXUP"]``              :py:attr:`.ImageCms.Flags.NOWHITEONWHITEFIXUP`
-``ImageCms.FLAGS["NOPRELINEARIZATION"]``               :py:attr:`.ImageCms.Flags.CLUT_PRE_LINEARIZATION`
-``ImageCms.FLAGS["GUESSDEVICECLASS"]``                 :py:attr:`.ImageCms.Flags.GUESSDEVICECLASS`
-``ImageCms.FLAGS["NOTCACHE"]``                         :py:attr:`.ImageCms.Flags.NOCACHE`
-``ImageCms.FLAGS["NOTPRECALC"]``                       :py:attr:`.ImageCms.Flags.NOOPTIMIZE`
-``ImageCms.FLAGS["NULLTRANSFORM"]``                    :py:attr:`.ImageCms.Flags.NULLTRANSFORM`
-``ImageCms.FLAGS["HIGHRESPRECALC"]``                   :py:attr:`.ImageCms.Flags.HIGHRESPRECALC`
-``ImageCms.FLAGS["LOWRESPRECALC"]``                    :py:attr:`.ImageCms.Flags.LOWRESPRECALC`
-``ImageCms.FLAGS["GAMUTCHECK"]``                       :py:attr:`.ImageCms.Flags.GAMUTCHECK`
-``ImageCms.FLAGS["WHITEBLACKCOMPENSATION"]``           :py:attr:`.ImageCms.Flags.BLACKPOINTCOMPENSATION`
-``ImageCms.FLAGS["BLACKPOINTCOMPENSATION"]``           :py:attr:`.ImageCms.Flags.BLACKPOINTCOMPENSATION`
-``ImageCms.FLAGS["SOFTPROOFING"]``                     :py:attr:`.ImageCms.Flags.SOFTPROOFING`
-``ImageCms.FLAGS["PRESERVEBLACK"]``                    :py:attr:`.ImageCms.Flags.NONEGATIVES`
-``ImageCms.FLAGS["NODEFAULTRESOURCEDEF"]``             :py:attr:`.ImageCms.Flags.NODEFAULTRESOURCEDEF`
-``ImageCms.FLAGS["GRIDPOINTS"]``                       :py:attr:`.ImageCms.Flags.GRIDPOINTS()`
-``ImageCms.versions()``                                :py:func:`PIL.features.version_module` with
-                                                       ``feature="littlecms2"``, :py:data:`sys.version` or
-                                                       :py:data:`sys.version_info`, and ``PIL.__version__``
-=====================================================  ============================================================
+============================================  ====================================================
+Deprecated                                    Use instead
+============================================  ====================================================
+``ImageCms.DESCRIPTION``                      No replacement
+``ImageCms.VERSION``                          ``PIL.__version__``
+``ImageCms.FLAGS["MATRIXINPUT"]``             :py:attr:`.ImageCms.Flags.CLUT_POST_LINEARIZATION`
+``ImageCms.FLAGS["MATRIXOUTPUT"]``            :py:attr:`.ImageCms.Flags.FORCE_CLUT`
+``ImageCms.FLAGS["MATRIXONLY"]``              No replacement
+``ImageCms.FLAGS["NOWHITEONWHITEFIXUP"]``     :py:attr:`.ImageCms.Flags.NOWHITEONWHITEFIXUP`
+``ImageCms.FLAGS["NOPRELINEARIZATION"]``      :py:attr:`.ImageCms.Flags.CLUT_PRE_LINEARIZATION`
+``ImageCms.FLAGS["GUESSDEVICECLASS"]``        :py:attr:`.ImageCms.Flags.GUESSDEVICECLASS`
+``ImageCms.FLAGS["NOTCACHE"]``                :py:attr:`.ImageCms.Flags.NOCACHE`
+``ImageCms.FLAGS["NOTPRECALC"]``              :py:attr:`.ImageCms.Flags.NOOPTIMIZE`
+``ImageCms.FLAGS["NULLTRANSFORM"]``           :py:attr:`.ImageCms.Flags.NULLTRANSFORM`
+``ImageCms.FLAGS["HIGHRESPRECALC"]``          :py:attr:`.ImageCms.Flags.HIGHRESPRECALC`
+``ImageCms.FLAGS["LOWRESPRECALC"]``           :py:attr:`.ImageCms.Flags.LOWRESPRECALC`
+``ImageCms.FLAGS["GAMUTCHECK"]``              :py:attr:`.ImageCms.Flags.GAMUTCHECK`
+``ImageCms.FLAGS["WHITEBLACKCOMPENSATION"]``  :py:attr:`.ImageCms.Flags.BLACKPOINTCOMPENSATION`
+``ImageCms.FLAGS["BLACKPOINTCOMPENSATION"]``  :py:attr:`.ImageCms.Flags.BLACKPOINTCOMPENSATION`
+``ImageCms.FLAGS["SOFTPROOFING"]``            :py:attr:`.ImageCms.Flags.SOFTPROOFING`
+``ImageCms.FLAGS["PRESERVEBLACK"]``           :py:attr:`.ImageCms.Flags.NONEGATIVES`
+``ImageCms.FLAGS["NODEFAULTRESOURCEDEF"]``    :py:attr:`.ImageCms.Flags.NODEFAULTRESOURCEDEF`
+``ImageCms.FLAGS["GRIDPOINTS"]``              :py:attr:`.ImageCms.Flags.GRIDPOINTS()`
+``ImageCms.versions()``                       :py:func:`PIL.features.version_module` with
+                                              ``feature="littlecms2"``, :py:data:`sys.version` or
+                                              :py:data:`sys.version_info`, and ``PIL.__version__``
+============================================  ====================================================
 
 Removed features
 ----------------

--- a/docs/reference/ExifTags.rst
+++ b/docs/reference/ExifTags.rst
@@ -4,8 +4,9 @@
 :py:mod:`~PIL.ExifTags` Module
 ==============================
 
-The :py:mod:`~PIL.ExifTags` module exposes several ``enum.IntEnum`` classes
-which provide constants and clear-text names for various well-known EXIF tags.
+The :py:mod:`~PIL.ExifTags` module exposes several :py:class:`enum.IntEnum`
+classes which provide constants and clear-text names for various well-known
+EXIF tags.
 
 .. py:data:: Base
 

--- a/docs/releasenotes/10.0.0.rst
+++ b/docs/releasenotes/10.0.0.rst
@@ -43,7 +43,7 @@ Constants
 ^^^^^^^^^
 
 A number of constants have been removed.
-Instead, ``enum.IntEnum`` classes have been added.
+Instead, :py:class:`enum.IntEnum` classes have been added.
 
 =====================================================  ============================================================
 Removed                                                Use instead

--- a/docs/releasenotes/10.3.0.rst
+++ b/docs/releasenotes/10.3.0.rst
@@ -17,33 +17,33 @@ A number of constants and a function in :py:mod:`.ImageCms` have been deprecated
 This includes a table of flags based on LittleCMS version 1 which has been replaced
 with a new class :py:class:`.ImageCms.Flags` based on LittleCMS 2 flags.
 
-=====================================================  ============================================================
-Deprecated                                             Use instead
-=====================================================  ============================================================
-``ImageCms.DESCRIPTION``                               No replacement
-``ImageCms.VERSION``                                   ``PIL.__version__``
-``ImageCms.FLAGS["MATRIXINPUT"]``                      :py:attr:`.ImageCms.Flags.CLUT_POST_LINEARIZATION`
-``ImageCms.FLAGS["MATRIXOUTPUT"]``                     :py:attr:`.ImageCms.Flags.FORCE_CLUT`
-``ImageCms.FLAGS["MATRIXONLY"]``                       No replacement
-``ImageCms.FLAGS["NOWHITEONWHITEFIXUP"]``              :py:attr:`.ImageCms.Flags.NOWHITEONWHITEFIXUP`
-``ImageCms.FLAGS["NOPRELINEARIZATION"]``               :py:attr:`.ImageCms.Flags.CLUT_PRE_LINEARIZATION`
-``ImageCms.FLAGS["GUESSDEVICECLASS"]``                 :py:attr:`.ImageCms.Flags.GUESSDEVICECLASS`
-``ImageCms.FLAGS["NOTCACHE"]``                         :py:attr:`.ImageCms.Flags.NOCACHE`
-``ImageCms.FLAGS["NOTPRECALC"]``                       :py:attr:`.ImageCms.Flags.NOOPTIMIZE`
-``ImageCms.FLAGS["NULLTRANSFORM"]``                    :py:attr:`.ImageCms.Flags.NULLTRANSFORM`
-``ImageCms.FLAGS["HIGHRESPRECALC"]``                   :py:attr:`.ImageCms.Flags.HIGHRESPRECALC`
-``ImageCms.FLAGS["LOWRESPRECALC"]``                    :py:attr:`.ImageCms.Flags.LOWRESPRECALC`
-``ImageCms.FLAGS["GAMUTCHECK"]``                       :py:attr:`.ImageCms.Flags.GAMUTCHECK`
-``ImageCms.FLAGS["WHITEBLACKCOMPENSATION"]``           :py:attr:`.ImageCms.Flags.BLACKPOINTCOMPENSATION`
-``ImageCms.FLAGS["BLACKPOINTCOMPENSATION"]``           :py:attr:`.ImageCms.Flags.BLACKPOINTCOMPENSATION`
-``ImageCms.FLAGS["SOFTPROOFING"]``                     :py:attr:`.ImageCms.Flags.SOFTPROOFING`
-``ImageCms.FLAGS["PRESERVEBLACK"]``                    :py:attr:`.ImageCms.Flags.NONEGATIVES`
-``ImageCms.FLAGS["NODEFAULTRESOURCEDEF"]``             :py:attr:`.ImageCms.Flags.NODEFAULTRESOURCEDEF`
-``ImageCms.FLAGS["GRIDPOINTS"]``                       :py:attr:`.ImageCms.Flags.GRIDPOINTS()`
-``ImageCms.versions()``                                :py:func:`PIL.features.version_module` with
-                                                       ``feature="littlecms2"``, :py:data:`sys.version` or
-                                                       :py:data:`sys.version_info`, and ``PIL.__version__``
-=====================================================  ============================================================
+============================================  ====================================================
+Deprecated                                    Use instead
+============================================  ====================================================
+``ImageCms.DESCRIPTION``                      No replacement
+``ImageCms.VERSION``                          ``PIL.__version__``
+``ImageCms.FLAGS["MATRIXINPUT"]``             :py:attr:`.ImageCms.Flags.CLUT_POST_LINEARIZATION`
+``ImageCms.FLAGS["MATRIXOUTPUT"]``            :py:attr:`.ImageCms.Flags.FORCE_CLUT`
+``ImageCms.FLAGS["MATRIXONLY"]``              No replacement
+``ImageCms.FLAGS["NOWHITEONWHITEFIXUP"]``     :py:attr:`.ImageCms.Flags.NOWHITEONWHITEFIXUP`
+``ImageCms.FLAGS["NOPRELINEARIZATION"]``      :py:attr:`.ImageCms.Flags.CLUT_PRE_LINEARIZATION`
+``ImageCms.FLAGS["GUESSDEVICECLASS"]``        :py:attr:`.ImageCms.Flags.GUESSDEVICECLASS`
+``ImageCms.FLAGS["NOTCACHE"]``                :py:attr:`.ImageCms.Flags.NOCACHE`
+``ImageCms.FLAGS["NOTPRECALC"]``              :py:attr:`.ImageCms.Flags.NOOPTIMIZE`
+``ImageCms.FLAGS["NULLTRANSFORM"]``           :py:attr:`.ImageCms.Flags.NULLTRANSFORM`
+``ImageCms.FLAGS["HIGHRESPRECALC"]``          :py:attr:`.ImageCms.Flags.HIGHRESPRECALC`
+``ImageCms.FLAGS["LOWRESPRECALC"]``           :py:attr:`.ImageCms.Flags.LOWRESPRECALC`
+``ImageCms.FLAGS["GAMUTCHECK"]``              :py:attr:`.ImageCms.Flags.GAMUTCHECK`
+``ImageCms.FLAGS["WHITEBLACKCOMPENSATION"]``  :py:attr:`.ImageCms.Flags.BLACKPOINTCOMPENSATION`
+``ImageCms.FLAGS["BLACKPOINTCOMPENSATION"]``  :py:attr:`.ImageCms.Flags.BLACKPOINTCOMPENSATION`
+``ImageCms.FLAGS["SOFTPROOFING"]``            :py:attr:`.ImageCms.Flags.SOFTPROOFING`
+``ImageCms.FLAGS["PRESERVEBLACK"]``           :py:attr:`.ImageCms.Flags.NONEGATIVES`
+``ImageCms.FLAGS["NODEFAULTRESOURCEDEF"]``    :py:attr:`.ImageCms.Flags.NODEFAULTRESOURCEDEF`
+``ImageCms.FLAGS["GRIDPOINTS"]``              :py:attr:`.ImageCms.Flags.GRIDPOINTS()`
+``ImageCms.versions()``                       :py:func:`PIL.features.version_module` with
+                                              ``feature="littlecms2"``, :py:data:`sys.version` or
+                                              :py:data:`sys.version_info`, and ``PIL.__version__``
+============================================  ====================================================
 
 API Changes
 ===========

--- a/docs/releasenotes/9.3.0.rst
+++ b/docs/releasenotes/9.3.0.rst
@@ -33,8 +33,9 @@ Added ExifTags enums
 ^^^^^^^^^^^^^^^^^^^^
 
 The data from :py:data:`~PIL.ExifTags.TAGS` and
-:py:data:`~PIL.ExifTags.GPSTAGS` is now also exposed as ``enum.IntEnum``
-classes: :py:data:`~PIL.ExifTags.Base` and :py:data:`~PIL.ExifTags.GPS`.
+:py:data:`~PIL.ExifTags.GPSTAGS` is now also exposed as
+:py:class:`enum.IntEnum` classes: :py:data:`~PIL.ExifTags.Base` and
+:py:data:`~PIL.ExifTags.GPS`.
 
 
 Security


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/7702, to continue replacing
```
``enum.IntEnum``
```
with
```
:py:class:`enum.IntEnum`
```