### PR TITLE
putalpha does not allow other color values

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2074,9 +2074,8 @@ class Image:
             if self.mode == "PA":
                 alpha = value[3] if len(value) == 4 else 255
                 value = value[:3]
-            value = self.palette.getcolor(value, self)
-            if self.mode == "PA":
-                value = (value, alpha)  # type: ignore[assignment]
+            palette_index = self.palette.getcolor(value, self)
+            value = (palette_index, alpha) if self.mode == "PA" else palette_index
         return self.im.putpixel(xy, value)
 
     def remap_palette(self, dest_map, source_palette=None):

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1933,8 +1933,7 @@ class Image:
         The new layer must be either "L" or "1".
 
         :param alpha: The new alpha layer.  This can either be an "L" or "1"
-           image having the same size as this image, or an integer or
-           other color value.
+           image having the same size as this image, or an integer.
         """
 
         self._ensure_mutable()

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -33,6 +33,7 @@ def grab(
     all_screens: bool = False,
     xdisplay: str | None = None,
 ) -> Image.Image:
+    im: Image.Image
     if xdisplay is None:
         if sys.platform == "darwin":
             fh, filepath = tempfile.mkstemp(".png")
@@ -42,7 +43,7 @@ def grab(
                 left, top, right, bottom = bbox
                 args += ["-R", f"{left},{top},{right-left},{bottom-top}"]
             subprocess.call(args + ["-x", filepath])
-            im: Image.Image = Image.open(filepath)
+            im = Image.open(filepath)
             im.load()
             os.unlink(filepath)
             if bbox:
@@ -84,7 +85,7 @@ def grab(
             fh, filepath = tempfile.mkstemp(".png")
             os.close(fh)
             subprocess.call(["gnome-screenshot", "-f", filepath])
-            im: Image.Image = Image.open(filepath)  # type: ignore[no-redef, unused-ignore]
+            im = Image.open(filepath)
             im.load()
             os.unlink(filepath)
             if bbox:

--- a/src/PIL/PyAccess.py
+++ b/src/PIL/PyAccess.py
@@ -107,9 +107,8 @@ class PyAccess:
             if self._im.mode == "PA":
                 alpha = color[3] if len(color) == 4 else 255
                 color = color[:3]
-            color = self._palette.getcolor(color, self._img)
-            if self._im.mode == "PA":
-                color = (color, alpha)  # type: ignore[assignment]
+            palette_index = self._palette.getcolor(color, self._img)
+            color = (palette_index, alpha) if self._im.mode == "PA" else palette_index
 
         return self.set_pixel(x, y, color)
 


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/8032

Updates the `putalpha()` docstring to match the hinted type.