### PR TITLE
Added type hints

### DIFF
--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -89,6 +89,7 @@ $bmp = New-Object Drawing.Bitmap 200, 200
         p.communicate()
 
         im = ImageGrab.grabclipboard()
+        assert isinstance(im, list)
         assert len(im) == 1
         assert os.path.samefile(im[0], "Tests/images/hopper.gif")
 
@@ -105,6 +106,7 @@ $ms = new-object System.IO.MemoryStream(, $bytes)
         p.communicate()
 
         im = ImageGrab.grabclipboard()
+        assert isinstance(im, Image.Image)
         assert_image_equal_tofile(im, "Tests/images/hopper.png")
 
     @pytest.mark.skipif(
@@ -120,6 +122,7 @@ $ms = new-object System.IO.MemoryStream(, $bytes)
         with open(image_path, "rb") as fp:
             subprocess.call(["wl-copy"], stdin=fp)
         im = ImageGrab.grabclipboard()
+        assert isinstance(im, Image.Image)
         assert_image_equal_tofile(im, image_path)
 
     @pytest.mark.skipif(

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -22,7 +22,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from typing import Union, cast
 
 from . import Image
 
@@ -70,15 +69,15 @@ def grab(
                 left, top, right, bottom = bbox
                 im = im.crop((left - x0, top - y0, right - x0, bottom - y0))
             return im
-    xdisplay = cast(Union[str, None], xdisplay)  # type: ignore[redundant-cast, unused-ignore]
+    display_name: str | None = xdisplay
     try:
         if not Image.core.HAVE_XCB:
             msg = "Pillow was built without XCB support"
             raise OSError(msg)
-        size, data = Image.core.grabscreen_x11(xdisplay)
+        size, data = Image.core.grabscreen_x11(display_name)
     except OSError:
         if (
-            xdisplay is None
+            display_name is None
             and sys.platform not in ("darwin", "win32")
             and shutil.which("gnome-screenshot")
         ):

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -69,6 +69,7 @@ def grab(
                 left, top, right, bottom = bbox
                 im = im.crop((left - x0, top - y0, right - x0, bottom - y0))
             return im
+    # Cast to Optional[str] needed for Windows and macOS.
     display_name: str | None = xdisplay
     try:
         if not Image.core.HAVE_XCB:


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/8032

- Added some type hints to tests to go with the ImageGrab changes
- Removed a cast in Image.py that isn't needed
- Used a new variable in ImageGrab instead of casting, which I think is simpler